### PR TITLE
Add support for 64bit long vectors in load.gwa.data()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GenABEL
 Type: Package
 Title: genome-wide SNP association analysis
-Version: 1.8-0
+Version: 1.8-1
 Date: 2013-12-09
 Author: GenABEL project developers
 Contact: GenABEL project developers <genabel.project at gmail.com>

--- a/GenABEL.Rproj
+++ b/GenABEL.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/sset.R
+++ b/R/sset.R
@@ -1,3 +1,9 @@
 "sset" <-
-function(data,nsnps,nids,list) .C("sset",as.raw(data), as.integer(nsnps), as.integer(nids), as.integer(list), as.integer(length(list)), cdata = raw(nsnps*ceiling(length(list)/4)), PACKAGE="GenABEL")$cdata
-
+function(data,nsnps,nids,list) {
+  result <-.Call("sset_call",as.raw(data), 
+               as.integer(nsnps), 
+               as.integer(nids), 
+               as.integer(list), 
+               as.integer(length(list)))
+  return(result)
+}

--- a/src/gwaa_cpp.cpp
+++ b/src/gwaa_cpp.cpp
@@ -1,4 +1,5 @@
 #include <new>
+#include <Rdefines.h>
 #include "gwaa_cpp.h"
 
 
@@ -7,8 +8,26 @@
 extern "C" {
 #endif
 
+void sset(char *indata, int *Nsnps, int *Nids, int *outlist, int *Noutlist, char *out);
 
-	/*
+/*
+ * Wraps in .Call interface
+ * void sset(char *indata, int *Nsnps, int *Nids, int *outlist, int *Noutlist, char *out) {
+ */
+SEXP sset_call(SEXP indata, SEXP Nsnps, SEXP Nids,
+               SEXP outlist, SEXP Noutlist) {
+  SEXP out;
+  //cdata = raw(nsnps*ceiling(length(list)/4))
+  int n_outlist = INTEGER(Noutlist)[0];
+  int n_snps = INTEGER(Nsnps)[0];
+  int n_outlist_by_4 = (n_outlist % 4 == 0) ? n_outlist/4 : n_outlist/4 + 1; 
+  PROTECT(out = NEW_RAW(n_snps * n_outlist_by_4));
+  sset((char*)RAW(indata), INTEGER(Nsnps), INTEGER(Nids), INTEGER(outlist), INTEGER(Noutlist), (char*)RAW(out));
+  UNPROTECT(1);
+  return out;
+}
+  
+/*
 // This code implements an exact SNP test of Hardy-Weinberg Equilibrium as described in
 // Wigginton, JE, Cutler, DJ, and Abecasis, GR (2005) A Note on Exact Tests of
 // Hardy-Weinberg Equilibrium. American Journal of Human Genetics. 76: 000 - 000


### PR DESCRIPTION
This seem to be related to sset() function using .C() interface which fails if the number of genotypes is larger than 2^32.